### PR TITLE
Fix for TRANSREL-30

### DIFF
--- a/config/Config-template.groovy
+++ b/config/Config-template.groovy
@@ -114,6 +114,13 @@ environments {
 }
 /* }}} */
 
+/* {{{ Data Upload Configuration - see GWAS plugin Data Upload page */
+// This is the value that will appear in the To: entry of the e-mail popup 
+// that is displayed when the user clicks the Email administrator button,
+// on the GWAS plugin Data Upload page
+com.recomdata.dataUpload.adminEmail = 'No data upload adminEmail value set - contact site administrator'
+/* }}} */
+
 /* {{{ Personalization */
 // application logo to be used in the login page
 com.recomdata.largeLogo = "transmartlogo.jpg"


### PR DESCRIPTION
In the Config.groovy templet, set the default value for the 'mail-to:' of the 'Email Administrator' button to a 'change this value' value that makes sense in the context of a user clicking on the button
