### PR TITLE
Fix for TRANSREL-121 - SOLR port = 8983

### DIFF
--- a/config/Config-template.groovy
+++ b/config/Config-template.groovy
@@ -14,7 +14,7 @@
 def catalinaBase      = System.getProperty('catalina.base') ?: '.'
 
 def explodedWarDir    = catalinaBase + '/webapps/transmart'
-def solrPort          = 8080 //port of appserver where solr runs (under ctx path /solr)
+def solrPort          = 8983 //port of appserver where solr runs (under ctx path /solr)
 def searchIndex       = catalinaBase + '/searchIndex' //create this directory
 // for running transmart as WAR, create this directory and then create an alias
 def jobsDirectory     = "/var/tmp/jobs/"


### PR DESCRIPTION
The default SOLR port in config/Config-template.groovy should be 8983.
